### PR TITLE
Auto-increment the date by one day upon submit

### DIFF
--- a/src/lib/TroiEntryForm.svelte
+++ b/src/lib/TroiEntryForm.svelte
@@ -59,6 +59,10 @@
       dispatch("submit");
       values.hours = "";
       values.description = "";
+      let nextDate = new Date(values.date.getTime());
+      // 5 = Friday, then jump over the weekend
+      nextDate.setDate(nextDate.getDate() + (nextDate.getDay() === 5 ? 3 : 1));
+      values.date = nextDate;
     }
   };
 


### PR DESCRIPTION
Feature suggestion by @NicolaiRidani 🌟 

In case for some people the default is to add multiple entries _per day_, a checkbox could make sense? Something like "`[ ] auto-advance the date upon submission`".