### PR TITLE
Add tooltip for Troi API token

### DIFF
--- a/src/routes/login/index.svelte
+++ b/src/routes/login/index.svelte
@@ -76,8 +76,11 @@
     </div>
 
     <div class="mt-4 w-full">
-      <label for="password" class="mb-2 block text-sm text-gray-600"
-        >Troi password</label
+      <label
+        title="Troi → security center → API v2 / Troi App → Token"
+        for="password"
+        class="mb-2 block text-sm text-gray-600"
+        >Troi password or Troi v2 token ⓘ</label
       >
       <Input
         bind:value={password}


### PR DESCRIPTION
As already mentioned in Slack, new users and users who changed their password need to use the Troi v2 API tokens since February.