### PR TITLE
Round end time to full 15m

### DIFF
--- a/app/routes/work_time.($id).tsx
+++ b/app/routes/work_time.($id).tsx
@@ -86,7 +86,9 @@ const DEFAULT_BREAK_TIME = 60;
 function getEndTime(workTime: number) {
   // calculate end time based on daily work time from personio
   const momentStartTime = moment(DEFAULT_START_TIME, "HH:mm");
-  const momentWorkTime = moment(minutesToTime(workTime * 60), "HH:mm");
+  // e.g. 36h work week results in 7:12 hours -> round up/down to full fifteen minutes
+  const workTimeMinutes = Math.round((workTime * 60) / 15) * 15;
+  const momentWorkTime = moment(minutesToTime(workTimeMinutes), "HH:mm");
 
   return momentStartTime
     .add(DEFAULT_BREAK_TIME, "minutes")


### PR DESCRIPTION
For part-time workers, the end time will be odd, e.g., for 36h/week the end time will default to 17:12. As we are supposed to book to the nearest 15 minutes, the end time should be rounded up/down. Otherwise, the +/- buttons are not usable without manual adjustments.

<img width="984" alt="image" src="https://github.com/user-attachments/assets/2120b404-1a6a-4f78-aac9-16bdd49d837a">
