### PR TITLE
Potential fix for code scanning alert no. 34: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -90,6 +90,8 @@ jobs:
 
   audit-licenses:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v5


### PR DESCRIPTION
Potential fix for [https://github.com/digitalservicebund/achill/security/code-scanning/34](https://github.com/digitalservicebund/achill/security/code-scanning/34)

To fix the flagged problem, add a `permissions` block to the `audit-licenses` job (under `jobs.audit-licenses`) in `.github/workflows/pipeline.yml`. Set the permissions to the minimum required, which in this case is `contents: read`. Place this block just below the `runs-on: ubuntu-latest` line (line 92), matching what is already done for the `vulnerability-scan` job. No changes elsewhere are required, and you do not need to install or import anything.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
