### PR TITLE
Potential fix for code scanning alert no. 33: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,5 +1,8 @@
 name: Pipeline
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/digitalservicebund/achill/security/code-scanning/33](https://github.com/digitalservicebund/achill/security/code-scanning/33)

The best way to fix this problem is to explicitly add a `permissions` block with the minimal privileges required. According to the background information and the recommendation, setting `contents: read` is a secure minimal baseline, unless a job requires more privileged access. 

You can do this:
- At the workflow level: adding `permissions: contents: read` at the top will apply to all jobs that do not specify their own permissions; exception jobs can override as necessary.
- Or at the job level: adding a `permissions: contents: read` under each job missing it (`build` and `audit-licenses`).

Since the rest of the workflow does not indicate any job besides `vulnerability-scan` needs more than this, the most straightforward and maintainable solution is to add the following after the `name:` block but before `env:`, to apply to all jobs except the ones that explicitly set their own permissions:

```yaml
permissions:
  contents: read
```

This will apply to `build` and `audit-licenses`. The job `vulnerability-scan` already specifies its own (more privileged) permission block.

**Files/Regions to change:**  
- File: `.github/workflows/pipeline.yml`
- Insert the permissions block immediately after the `name: Pipeline` line (line 1), before `env:` (which starts on line 11).

**No other changes or imports are required.**

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
