### PR TITLE
Potential fix for code scanning alert no. 32: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/secrets-check.yml
+++ b/.github/workflows/secrets-check.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   check:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Potential fix for [https://github.com/digitalservicebund/achill/security/code-scanning/32](https://github.com/digitalservicebund/achill/security/code-scanning/32)

To fix the problem, an explicit `permissions` block should be added to the job definition in the `.github/workflows/secrets-check.yml` workflow file. The minimal starting point is `contents: read`, which restricts the GITHUB_TOKEN's access to the repository contents to read-only. This should be sufficient for the actions used in the workflow: checkout, linting, and sending Slack notifications (none of which require write permissions). The change should be made immediately after the job name and before the `runs-on` key (inside the `check` job). No additional dependencies or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
